### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/obsidianrag/core/qa_agent.py
+++ b/backend/obsidianrag/core/qa_agent.py
@@ -620,4 +620,7 @@ async def ask_question_graph_streaming(
         import traceback
 
         logger.error(traceback.format_exc())
-        yield {"type": "error", "message": str(e)}
+        yield {
+            "type": "error",
+            "message": "An error occurred while processing your request",
+        }


### PR DESCRIPTION
Potential fix for [https://github.com/Vasallo94/ObsidianRAG/security/code-scanning/2](https://github.com/Vasallo94/ObsidianRAG/security/code-scanning/2)

The best fix is to keep detailed exception information in server logs, but return only a generic, user-safe error message to clients.

Specifically:
- In `backend/obsidianrag/core/qa_agent.py`, in the `except Exception as e:` block of `ask_question_graph_streaming`, replace the yielded error payload so it does **not** include `str(e)`.
- Keep existing logging (including traceback) so operators still have debugging visibility.
- No functional behavior change to streaming protocol shape is needed (`type: "error"` remains), only sanitization of `message`.

Target region:
- `backend/obsidianrag/core/qa_agent.py`, around lines 618–623 in the snippet provided.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
