### PR TITLE
fix: fuse hybrid rankings by source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External evaluation now rejects citations outside retrieved context and gives that context to the judge
 - Evaluation comparisons now reject incompatible retrieval depths and ground-truth annotations
 - Adaptive hybrid context uses the strongest lexical score even when a vector-only result ranks first
+- Hybrid RRF now fuses lexical and vector rankings by source before selecting the strongest lexical passage
 - Query pipeline shutdown waits for active SQLite retrieval before closing the connection
 - Read-only SQLite index URIs now safely encode cross-platform paths
 - Indexing now excludes Obsidian internals, trash, Git data, and dependency directories

--- a/backend/obsidianrag/v4/retrieval.py
+++ b/backend/obsidianrag/v4/retrieval.py
@@ -90,38 +90,39 @@ class ExperimentalRetriever:
         candidates = max(k * 5, 25)
         lexical = self._lexical_search(query, candidates)
         vector = self._vector_search(query, candidates)
-        scores: defaultdict[str, float] = defaultdict(float)
-        channels: defaultdict[str, set[str]] = defaultdict(set)
-
-        for channel, ranked_ids in (("lexical", lexical), ("vector", vector)):
-            for rank, chunk_id in enumerate(ranked_ids, 1):
-                scores[chunk_id] += 1.0 / (RRF_CONSTANT + rank)
-                channels[chunk_id].add(channel)
-
-        ranked = sorted(scores, key=scores.__getitem__, reverse=True)
-        if not ranked:
+        chunk_ids = list(dict.fromkeys([*lexical, *vector]))
+        if not chunk_ids:
             return []
-        placeholders = ",".join("?" for _ in ranked)
+        placeholders = ",".join("?" for _ in chunk_ids)
         rows = {
             row[0]: row
             for row in self.connection.execute(
                 f"SELECT chunk_id, note_path, ordinal, text FROM chunks "
                 f"WHERE chunk_id IN ({placeholders})",
-                ranked,
+                chunk_ids,
             )
         }
-        source_candidates = []
+
+        source_scores: defaultdict[str, float] = defaultdict(float)
+        for ranked_ids in (lexical, vector):
+            seen_sources = set()
+            source_rank = 0
+            for chunk_id in ranked_ids:
+                row = rows.get(chunk_id)
+                if row is None or row[1] in seen_sources:
+                    continue
+                seen_sources.add(row[1])
+                source_rank += 1
+                source_scores[row[1]] += 1.0 / (RRF_CONSTANT + source_rank)
+
+        source_candidates = sorted(
+            source_scores, key=lambda source: (-source_scores[source], source)
+        )[:k]
         fallback_rows = {}
-        source_scores = {}
-        for chunk_id in ranked:
+        for chunk_id in chunk_ids:
             row = rows.get(chunk_id)
-            if row is None or row[1] in fallback_rows:
-                continue
-            source_candidates.append(row[1])
-            fallback_rows[row[1]] = row
-            source_scores[row[1]] = scores[chunk_id]
-            if len(source_candidates) == k:
-                break
+            if row is not None and row[1] not in fallback_rows:
+                fallback_rows[row[1]] = row
 
         documents = []
         for source in source_candidates:
@@ -150,7 +151,7 @@ class ExperimentalRetriever:
         expression = " OR ".join(f'"{term}"' for term in terms)
         rows = self.connection.execute(
             "SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH ? "
-            "ORDER BY bm25(chunks_fts) LIMIT ?",
+            "ORDER BY bm25(chunks_fts), chunk_id LIMIT ?",
             (expression, limit),
         )
         return [row[0] for row in rows]
@@ -159,12 +160,12 @@ class ExperimentalRetriever:
         terms = re.findall(r"\w+", query, flags=re.UNICODE)
         if not terms:
             return None
-        expression = " OR ".join(f'"{term}"' for term in terms)
+        expression = "text : (" + " OR ".join(f'"{term}"' for term in terms) + ")"
         return self.connection.execute(
             "SELECT c.chunk_id, c.note_path, c.ordinal, c.text, bm25(chunks_fts) "
             "FROM chunks_fts JOIN chunks c ON c.chunk_id = chunks_fts.chunk_id "
             "WHERE chunks_fts MATCH ? AND c.note_path = ? "
-            "ORDER BY bm25(chunks_fts) LIMIT 1",
+            "ORDER BY bm25(chunks_fts), c.ordinal, c.chunk_id LIMIT 1",
             (expression, source),
         ).fetchone()
 

--- a/backend/tests/test_v4_experimental.py
+++ b/backend/tests/test_v4_experimental.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import shutil
+import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -63,6 +64,85 @@ def test_build_and_search_experimental_index(tmp_path):
     assert len({document.metadata["source"] for document in documents}) == len(documents)
     assert lexical_documents[0].metadata["source"] == "Reference/Error Codes.md"
     assert lexical_documents[0].metadata["retrieval_type"] == "lexical"
+
+
+def test_hybrid_rrf_fuses_different_chunks_from_the_same_source():
+    retriever = ExperimentalRetriever.__new__(ExperimentalRetriever)
+    retriever.connection = sqlite3.connect(":memory:")
+    retriever.connection.execute(
+        "CREATE TABLE chunks (chunk_id TEXT, note_path TEXT, ordinal INTEGER, text TEXT)"
+    )
+    retriever.connection.executemany(
+        "INSERT INTO chunks VALUES (?, ?, ?, ?)",
+        [
+            ("b1", "B.md", 0, "B"),
+            ("a1", "A.md", 0, "A lexical"),
+            ("a2", "A.md", 1, "A vector"),
+            ("c1", "C.md", 0, "C"),
+        ],
+    )
+    try:
+        with (
+            patch.object(retriever, "_lexical_search", return_value=["b1", "a1"]),
+            patch.object(retriever, "_vector_search", return_value=["a2", "c1"]),
+            patch.object(
+                retriever,
+                "_best_lexical_chunk",
+                return_value=("a1", "A.md", 0, "A lexical", -10.0),
+            ),
+        ):
+            documents = retriever.invoke("query", k=1)
+    finally:
+        retriever.close()
+
+    assert documents[0].metadata == {
+        "chunk_id": "a1",
+        "source": "A.md",
+        "ordinal": 0,
+        "score": pytest.approx(1 / 61 + 1 / 62),
+        "lexical_score": 10.0,
+        "retrieval_type": "hybrid-source+lexical-chunk",
+    }
+    assert documents[0].page_content == "A lexical"
+
+
+def test_best_lexical_chunk_ignores_title_only_matches():
+    retriever = ExperimentalRetriever.__new__(ExperimentalRetriever)
+    retriever.connection = sqlite3.connect(":memory:")
+    retriever.connection.executescript(
+        """
+        CREATE TABLE chunks (
+            chunk_id TEXT PRIMARY KEY,
+            note_path TEXT,
+            ordinal INTEGER,
+            text TEXT
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            chunk_id UNINDEXED,
+            note_path UNINDEXED,
+            title,
+            text
+        );
+        """
+    )
+    rows = [
+        ("one", "Needle.md", 0, "No matching body text"),
+        ("two", "Needle.md", 1, "The needle is in this passage"),
+    ]
+    retriever.connection.executemany("INSERT INTO chunks VALUES (?, ?, ?, ?)", rows)
+    retriever.connection.executemany(
+        "INSERT INTO chunks_fts VALUES (?, ?, ?, ?)",
+        [(chunk_id, source, "TitleOnly", text) for chunk_id, source, _, text in rows],
+    )
+
+    try:
+        match = retriever._best_lexical_chunk("needle", "Needle.md")
+        title_only = retriever._best_lexical_chunk("TitleOnly", "Needle.md")
+    finally:
+        retriever.close()
+
+    assert match[:4] == ("two", "Needle.md", 1, "The needle is in this passage")
+    assert title_only is None
 
 
 def test_lexical_retriever_streams_from_pipeline_worker_thread(tmp_path):


### PR DESCRIPTION
## Summary

- convert lexical and vector chunk rankings into unique source rankings before RRF
- fuse evidence found in different chunks of the same note
- select the strongest text-matching lexical chunk only after ranking sources
- use deterministic source, chunk, and passage tie-breakers
- add regressions for cross-chunk fusion and title-only FTS matches

## Private validation

48-case hybrid retrieval:

- Recall@5: 0.990
- MRR: 0.930
- MAP@5: 0.909
- nDCG@5: 0.934
- Evidence recall@5: 0.728
- Mean latency: 209 ms

Adaptive multipart hybrid context:

- Recall@5: 0.979
- MRR: 0.925
- nDCG@5: 0.929
- Evidence recall@5: 0.718
- Mean context: 2.17 sources

The adaptive hybrid path still misses the <250 ms p95 release gate because multipart questions require multiple remote Ollama embedding calls. FTS5 remains the stronger low-latency generation path for now.

## Validation

- Ruff and format checks
- mypy
- 131 backend tests passed; 18 integration/slow tests deselected

## Merge gate

Do not merge until an independent fresh-context reviewer approves this PR. The current session exhausted its fresh-agent budget after retrospectively reviewing #53-#57 and reviewing #58 before merge.
