### PR TITLE
fix: prepare ObsidianRAG 4.0.1

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -33,6 +33,10 @@ jobs:
         working-directory: ./backend
         run: uv build
 
+      - name: Verify license artifacts
+        working-directory: ./backend
+        run: python scripts/verify_dist.py
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -28,6 +28,8 @@ jobs:
           - os: macos-latest
             python-version: '3.12'
           - os: windows-latest
+            python-version: '3.11'
+          - os: windows-latest
             python-version: '3.12'
 
     runs-on: ${{ matrix.os }}
@@ -48,7 +50,10 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --locked --dev
+        run: uv sync --locked --dev --python ${{ matrix.python-version }}
+
+      - name: Verify Python version
+        run: uv run python -c "import sys; assert sys.version_info[:2] == tuple(map(int, '${{ matrix.python-version }}'.split('.')))"
 
       - name: Run linting
         run: |
@@ -66,6 +71,12 @@ jobs:
       #       --cov=obsidianrag \
       #       --cov-append \
       #       --cov-report=xml
+
+      - name: Verify package artifacts
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        run: |
+          uv build
+          uv run python scripts/verify_dist.py
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -94,8 +105,10 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: |
-          uv sync --locked --dev
+        run: uv sync --locked --dev --python 3.11
+
+      - name: Verify Python version
+        run: uv run python -c "import sys; assert sys.version_info[:2] == (3, 11)"
 
       - name: Run type checking
         run: uv run mypy .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-08-03
+
+### Added
+- MIT license files are included in both backend wheel and source distributions
+- Windows Python 3.11 is part of the backend CI matrix
+
+### Fixed
+- Windows reparse points, including junctions, are rejected on Python 3.11 during indexing and cleanup
+- Plugin chat views preserve backend session IDs across turns; clearing a chat also invalidates in-flight turns
+- Backend requests for the same session are serialized without blocking independent sessions
+- Installation documentation now reflects the explicit v4 index lifecycle and `obsidianrag version`
+
 ## [4.0.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ ObsidianRAG 4 uses SQLite FTS5 and embedded LanceDB as its only retrieval engine
 Install the backend:
 
 ```bash
-uv tool install obsidianrag==4.0.0
+uv tool install obsidianrag==4.0.1
 ```
 
-Install the plugin assets from the `plugin-v4.0.0` GitHub release:
+Install the plugin assets from the `plugin-v4.0.1` GitHub release:
 
 - `main.js`
 - `manifest.json`
@@ -130,16 +130,16 @@ Readers lease their current revision. A new revision may activate while old requ
 | `POST /index/build` | Incremental build or explicit full rebuild |
 | `POST /index/prune` | Remove unleased inactive revisions |
 
-API 3 clients and backends are intentionally incompatible with 4.0.0.
+API 3 clients and backends are intentionally incompatible with 4.0.1.
 
 ## Migration from 3.x
 
-- Install backend and plugin 4.0.0 together.
+- Install backend and plugin 4.0.1 together.
 - Existing `.obsidianrag/v4` revisions are reused when compatible.
 - Legacy `.obsidianrag/db` Chroma data is ignored and never deleted automatically.
 - Replace compound backend commands such as `uv run obsidianrag` with an executable path or name.
 - Build the v4 index explicitly if no compatible revision exists.
-- Remove legacy index data manually only after validating 4.0.0.
+- Remove legacy index data manually only after validating 4.0.1.
 
 ## Development
 
@@ -164,10 +164,10 @@ Tests use temporary fixture vaults. Integration tests requiring a real provider 
 
 ## Release
 
-Backend and plugin share version `4.0.0` but publish independently:
+Backend and plugin share version `4.0.1` but publish independently:
 
-1. Tag `backend-v4.0.0` and verify PyPI.
-2. Tag `plugin-v4.0.0` and verify GitHub release assets.
+1. Tag `backend-v4.0.1` and verify PyPI.
+2. Tag `plugin-v4.0.1` and verify GitHub release assets.
 
 ## License
 

--- a/backend/LICENSE
+++ b/backend/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2024] [Enrique Vasallo Fernández]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,12 +5,12 @@ Python 3.11+ backend for the ObsidianRAG API, CLI, revisioned SQLite FTS5 catalo
 ## Install
 
 ```bash
-pip install obsidianrag==4.0.0
+pip install obsidianrag==4.0.1
 # or
-uv tool install obsidianrag==4.0.0
+uv tool install obsidianrag==4.0.1
 ```
 
-LanceDB is a standard dependency in 4.0.0; no extra is required.
+LanceDB is a standard dependency in 4.0.1; no extra is required.
 
 ## Commands
 

--- a/backend/obsidianrag/__init__.py
+++ b/backend/obsidianrag/__init__.py
@@ -1,6 +1,6 @@
 """ObsidianRAG v4: revisioned SQLite FTS5 and LanceDB retrieval."""
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __author__ = "Enrique Vasallo"
 
 __all__ = ["__version__"]

--- a/backend/obsidianrag/api/server.py
+++ b/backend/obsidianrag/api/server.py
@@ -63,6 +63,12 @@ class _LRUSessionStore:
             self._store.popitem(last=False)
 
 
+@dataclass
+class _SessionLock:
+    lock: asyncio.Lock
+    users: int = 0
+
+
 @dataclass(eq=False)
 class _PipelineSlot:
     pipeline: QueryPipeline
@@ -83,10 +89,44 @@ class _Runtime:
         self.vault_path = vault_path.resolve() if vault_path is not None else None
         self.settings = settings or get_settings().model_copy(deep=True)
         self.histories = _LRUSessionStore()
+        self._session_locks: OrderedDict[str, _SessionLock] = OrderedDict()
+        self._session_locks_guard = asyncio.Lock()
         self._state_lock = asyncio.Lock()
         self._index_lock = asyncio.Lock()
         self._serving: _PipelineSlot | None = None
         self._retired: list[_PipelineSlot] = []
+
+    @asynccontextmanager
+    async def session_turn(self, session_id: str) -> AsyncIterator[None]:
+        async with self._session_locks_guard:
+            entry = self._session_locks.get(session_id)
+            if entry is None:
+                entry = _SessionLock(asyncio.Lock())
+                self._session_locks[session_id] = entry
+            entry.users += 1
+            self._session_locks.move_to_end(session_id)
+            self._trim_session_locks()
+        try:
+            async with entry.lock:
+                yield
+        finally:
+            async with self._session_locks_guard:
+                entry.users -= 1
+                self._trim_session_locks()
+
+    def _trim_session_locks(self) -> None:
+        while len(self._session_locks) > MAX_SESSIONS:
+            idle = next(
+                (
+                    session_id
+                    for session_id, entry in self._session_locks.items()
+                    if entry.users == 0
+                ),
+                None,
+            )
+            if idle is None:
+                return
+            del self._session_locks[idle]
 
     async def startup(self) -> None:
         if self.vault_path is None:
@@ -348,34 +388,35 @@ def _register_routes(application: FastAPI) -> None:
     @application.post("/ask", response_model=Answer, summary="Ask a question")
     async def ask(question: Question):
         start_time = time.time()
-        try:
-            slot = await runtime.acquire()
-        except _IndexNotReady as error:
-            raise _error(503, "index_not_ready", "Build or load the v4 index first") from error
-        try:
-            session_id = question.session_id or str(uuid.uuid4())
-            history = runtime.histories.get(session_id)
-            result = await await_thread(slot.pipeline.ask, question.text, history)
-            history.append((question.text, result.answer))
-            runtime.histories.set(session_id, history)
-            sources = _source_list(result.documents)
-            return Answer(
-                question=result.question,
-                result=result.answer,
-                sources=sources,
-                text_blocks=[document.page_content for document in result.documents],
-                process_time=time.time() - start_time,
-                session_id=session_id,
-            )
-        except ValueError as error:
-            raise _error(400, "invalid_question", "Question is invalid") from error
-        except HTTPException:
-            raise
-        except Exception as error:
-            logger.error("Query failed: %s", error, exc_info=True)
-            raise _error(500, "query_failed", "The query could not be completed") from error
-        finally:
-            await runtime.release(slot)
+        session_id = question.session_id or str(uuid.uuid4())
+        async with runtime.session_turn(session_id):
+            try:
+                slot = await runtime.acquire()
+            except _IndexNotReady as error:
+                raise _error(503, "index_not_ready", "Build or load the v4 index first") from error
+            try:
+                history = runtime.histories.get(session_id)
+                result = await await_thread(slot.pipeline.ask, question.text, history)
+                history.append((question.text, result.answer))
+                runtime.histories.set(session_id, history)
+                sources = _source_list(result.documents)
+                return Answer(
+                    question=result.question,
+                    result=result.answer,
+                    sources=sources,
+                    text_blocks=[document.page_content for document in result.documents],
+                    process_time=time.time() - start_time,
+                    session_id=session_id,
+                )
+            except ValueError as error:
+                raise _error(400, "invalid_question", "Question is invalid") from error
+            except HTTPException:
+                raise
+            except Exception as error:
+                logger.error("Query failed: %s", error, exc_info=True)
+                raise _error(500, "query_failed", "The query could not be completed") from error
+            finally:
+                await runtime.release(slot)
 
     @application.post("/ask/stream", summary="Ask a question with streaming")
     async def ask_stream(question: Question):
@@ -385,27 +426,28 @@ def _register_routes(application: FastAPI) -> None:
             raise _error(503, "index_not_ready", "Build or load the v4 index first") from error
 
         session_id = question.session_id or str(uuid.uuid4())
-        history = runtime.histories.get(session_id)
 
         async def event_generator() -> AsyncGenerator[str, None]:
-            last_event: dict[str, Any] | None = None
-            try:
-                yield f"data: {json.dumps({'type': 'start', 'session_id': session_id})}\n\n"
-                async for event in slot.pipeline.stream(question.text, history):
-                    last_event = event
+            async with runtime.session_turn(session_id):
+                history = runtime.histories.get(session_id)
+                last_event: dict[str, Any] | None = None
+                try:
+                    yield f"data: {json.dumps({'type': 'start', 'session_id': session_id})}\n\n"
+                    async for event in slot.pipeline.stream(question.text, history):
+                        last_event = event
+                        yield f"data: {json.dumps(event)}\n\n"
+                    if last_event and last_event.get("type") == "answer":
+                        history.append((question.text, str(last_event.get("answer", ""))))
+                        runtime.histories.set(session_id, history)
+                except Exception as error:
+                    logger.error("Streaming query failed: %s", error, exc_info=True)
+                    event = {
+                        "type": "error",
+                        "code": "query_failed",
+                        "message": "The query could not be completed",
+                    }
                     yield f"data: {json.dumps(event)}\n\n"
-                if last_event and last_event.get("type") == "answer":
-                    history.append((question.text, str(last_event.get("answer", ""))))
-                    runtime.histories.set(session_id, history)
-            except Exception as error:
-                logger.error("Streaming query failed: %s", error, exc_info=True)
-                event = {
-                    "type": "error",
-                    "code": "query_failed",
-                    "message": "The query could not be completed",
-                }
-                yield f"data: {json.dumps(event)}\n\n"
-            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
         return StreamingResponse(
             event_generator(),

--- a/backend/obsidianrag/v4/index.py
+++ b/backend/obsidianrag/v4/index.py
@@ -125,18 +125,19 @@ def require_lancedb():
 
 def _is_link(path: Path) -> bool:
     try:
-        if path.is_symlink():
-            return True
-        is_junction = getattr(path, "is_junction", None)
-        return bool(is_junction and is_junction())
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return False
     except OSError as error:
         raise IndexPathError(f"Could not inspect managed path {path}: {error}") from error
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    attributes = getattr(metadata, "st_file_attributes", 0)
+    return stat.S_ISLNK(metadata.st_mode) or bool(attributes & reparse_point)
 
 
 def _reject_link(path: Path) -> None:
-    if path.exists() or path.is_symlink():
-        if _is_link(path):
-            raise IndexPathError(f"Managed v4 paths cannot be links: {path}")
+    if _is_link(path):
+        raise IndexPathError(f"Managed v4 paths cannot be links: {path}")
 
 
 def _ensure_directory(path: Path) -> Path:
@@ -825,7 +826,7 @@ def _scan_vault(vault: Path) -> dict[str, _NoteSnapshot]:
             if directory in EXCLUDED_DIRECTORIES:
                 continue
             if _is_link(candidate):
-                continue
+                raise IndexPathError(f"Markdown note paths cannot contain links: {candidate}")
             safe_directories.append(directory)
         directories[:] = safe_directories
         for filename in sorted(files):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "obsidianrag"
-version = "4.0.0"
+version = "4.0.1"
 description = "RAG system for querying Obsidian notes with SQLite FTS5 and LanceDB"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {text = "MIT"}
+license = {file = "LICENSE"}
 authors = [
     {name = "Enrique Vasallo"}
 ]

--- a/backend/scripts/verify_dist.py
+++ b/backend/scripts/verify_dist.py
@@ -1,0 +1,18 @@
+"""Verify required files in built backend distributions."""
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def _contains_license(names: list[str]) -> bool:
+    return any(Path(name).name == "LICENSE" for name in names)
+
+
+dist = Path("dist")
+wheel = next(dist.glob("*.whl"))
+source = next(dist.glob("*.tar.gz"))
+with zipfile.ZipFile(wheel) as wheel_archive:
+    assert _contains_license(wheel_archive.namelist()), f"LICENSE missing from {wheel.name}"
+with tarfile.open(source) as source_archive:
+    assert _contains_license(source_archive.getnames()), f"LICENSE missing from {source.name}"

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
 from unittest.mock import MagicMock
@@ -170,6 +171,55 @@ def test_missing_pipeline_queries_return_structured_503(
         }
 
 
+def test_same_session_turns_serialize_without_blocking_other_sessions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    pipeline = _pipeline()
+    started = Event()
+    release = Event()
+    observed: list[tuple[str, list[tuple[str, str]]]] = []
+    template = pipeline.ask.return_value
+
+    def controlled_ask(question: str, history: list[tuple[str, str]]) -> QueryResult:
+        observed.append((question, list(history)))
+        if question == "first":
+            started.set()
+            assert release.wait(5)
+        return QueryResult(
+            question=question,
+            answer=f"{question} answer",
+            documents=template.documents,
+            citations=template.citations,
+        )
+
+    pipeline.ask.side_effect = controlled_ask
+    app, _, _ = _configure(
+        monkeypatch, tmp_path, statuses=_status("current", "revision-1"), pipelines=[pipeline]
+    )
+
+    with TestClient(app) as client, ThreadPoolExecutor(max_workers=3) as executor:
+        first = executor.submit(client.post, "/ask", json={"text": "first", "session_id": "shared"})
+        assert started.wait(2)
+        second = executor.submit(
+            client.post, "/ask", json={"text": "second", "session_id": "shared"}
+        )
+        other = executor.submit(
+            client.post, "/ask", json={"text": "other", "session_id": "independent"}
+        )
+        try:
+            assert other.result(timeout=2).status_code == 200
+            assert not second.done()
+        finally:
+            release.set()
+        assert first.result(timeout=2).status_code == 200
+        assert second.result(timeout=2).status_code == 200
+
+    histories = {question: history for question, history in observed}
+    assert histories["first"] == []
+    assert histories["other"] == []
+    assert histories["second"] == [("first", "first answer")]
+
+
 def test_ask_uses_v4_pipeline_and_preserves_response_shape(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
@@ -187,6 +237,31 @@ def test_ask_uses_v4_pipeline_and_preserves_response_shape(
     assert response.json()["text_blocks"] == ["Evidence"]
     pipeline.ask.assert_called_once()
     pipeline.close.assert_called_once_with()
+
+
+def test_stream_history_propagates_to_the_next_session_turn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    pipeline = _pipeline("Stream answer [1]")
+    observed: list[tuple[str, list[tuple[str, str]]]] = []
+    template: QueryResult = pipeline.ask.return_value
+
+    def record_history(question: str, history: list[tuple[str, str]]) -> QueryResult:
+        observed.append((question, list(history)))
+        return template
+
+    pipeline.ask.side_effect = record_history
+    app, _, _ = _configure(
+        monkeypatch, tmp_path, statuses=_status("current", "revision-1"), pipelines=[pipeline]
+    )
+
+    with TestClient(app) as client:
+        streamed = client.post("/ask/stream", json={"text": "First", "session_id": "shared"})
+        answer = client.post("/ask", json={"text": "Second", "session_id": "shared"})
+
+    assert streamed.status_code == 200
+    assert answer.status_code == 200
+    assert observed == [("Second", [("First", "Stream answer [1]")])]
 
 
 def test_successful_build_swaps_and_closes_unused_old_slot(

--- a/backend/tests/test_v4_incremental.py
+++ b/backend/tests/test_v4_incremental.py
@@ -4,7 +4,10 @@ import json
 import multiprocessing
 import os
 import sqlite3
+import stat
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.embeddings import Embeddings
@@ -62,6 +65,15 @@ def _hold_build_lock(root: str, ready, release) -> None:
     with _build_lock(Path(root)):
         ready.set()
         release.wait(10)
+
+
+def test_reparse_file_attribute_is_treated_as_a_link(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    metadata = MagicMock(st_mode=stat.S_IFDIR, st_file_attributes=0x400)
+    monkeypatch.setattr(index_module.os, "lstat", MagicMock(return_value=metadata))
+
+    assert index_module._is_link(tmp_path / "junction")
 
 
 def test_pid_liveness_check_does_not_signal_the_current_process():
@@ -350,6 +362,54 @@ def test_managed_paths_and_markdown_notes_reject_links(tmp_path: Path):
     (vault / "linked.md").symlink_to(secret)
     with pytest.raises(IndexPathError, match="cannot contain links"):
         build_index(vault, KeywordEmbeddings())
+
+
+def _windows_junction(link: Path, target: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows junction coverage runs only on Windows")
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if os.environ.get("CI"):
+            pytest.fail(f"Windows CI could not create a junction: {detail}")
+        pytest.skip(f"Windows junction creation is unavailable: {detail}")
+
+
+def test_windows_reparse_points_cannot_enter_index_or_cleanup(tmp_path: Path):
+    vault = copy_sample_vault(tmp_path)
+    configure_from_vault(str(vault))
+    managed_target = tmp_path / "managed-target"
+    managed_target.mkdir()
+    managed_root = vault / ".obsidianrag"
+    _windows_junction(managed_root, managed_target)
+    with pytest.raises(IndexPathError, match="links"):
+        build_index(vault, KeywordEmbeddings())
+    managed_root.rmdir()
+
+    note_target = tmp_path / "external-notes"
+    note_target.mkdir()
+    (note_target / "Secret.md").write_text("external secret")
+    note_link = vault / "linked-notes"
+    _windows_junction(note_link, note_target)
+    with pytest.raises(IndexPathError, match="links"):
+        build_index(vault, KeywordEmbeddings())
+    note_link.rmdir()
+
+    build_index(vault, KeywordEmbeddings())
+    external_revision = tmp_path / "external-revision"
+    external_revision.mkdir()
+    marker = external_revision / "keep.txt"
+    marker.write_text("keep")
+    linked_revision = vault / ".obsidianrag" / "v4" / "indexes" / "linked-revision"
+    _windows_junction(linked_revision, external_revision)
+    with pytest.raises(IndexPathError, match="links"):
+        prune_revisions(vault)
+    assert marker.read_text() == "keep"
 
 
 def test_managed_v4_directory_rejects_link(tmp_path: Path):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1265,7 +1265,7 @@ wheels = [
 
 [[package]]
 name = "obsidianrag"
-version = "4.0.0"
+version = "4.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -30,7 +30,7 @@ Automated tests must use temporary/sample vaults and mocked providers.
 
 Exercise macOS, Linux, and Windows before release.
 
-1. Install backend 4.0.0 and plugin 4.0.0.
+1. Install backend 4.0.1 and plugin 4.0.1.
 2. Configure the backend executable (`obsidianrag.exe` on Windows).
 3. Verify process startup uses no shell and accepts vault paths containing spaces.
 4. Start with a test vault that has no index.
@@ -50,12 +50,12 @@ Never use a personal vault for release validation.
 
 Backend:
 
-- wheel and source distribution report version 4.0.0;
+- wheel and source distribution report version 4.0.1;
 - normal installation includes LanceDB;
-- `obsidianrag.__version__` reports 4.0.0.
+- `obsidianrag.__version__` reports 4.0.1.
 
 Plugin:
 
-- `package.json` and `manifest.json` report 4.0.0;
+- `package.json` and `manifest.json` report 4.0.1;
 - `main.js`, `manifest.json`, and `styles.css` are present;
 - API 3 backends are rejected.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -14,7 +14,7 @@ Check that port 8000 is free or configure another port.
 
 ## Plugin reports an incompatible backend
 
-Plugin 4.0.0 accepts only `api_version: 4`.
+Plugin 4.0.1 accepts only `api_version: 4`.
 
 ```bash
 curl http://127.0.0.1:8000/capabilities

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,63 +1,71 @@
 # Installation Guide
 
-## Prerequisites
+ObsidianRAG 4 requires matching backend and plugin releases. It does not index a vault automatically.
 
-Before installing ObsidianRAG, ensure you have the following components ready:
+## Requirements
 
-1.  **Obsidian**: Version 1.5.0 or higher.
-2.  **Python**: Version 3.11 or higher.
-    -   Verify with `python --version` in your terminal.
-    -   If not installed, download from [python.org](https://www.python.org/downloads/).
-3.  **Ollama**: For running the local LLM.
-    -   Download from [ollama.ai](https://ollama.ai).
-    -   Start the Ollama server (usually runs in the background).
-4.  **LLM Model**: Pull a model to use (e.g., `gemma3`).
-    -   Run `ollama pull gemma3` in your terminal.
+- Obsidian 1.5 or newer
+- Python 3.11 or newer
+- An Ollama, LM Studio, or compatible generation server with an available model
 
-## Step 1: Install the Backend
+## Install the backend
 
-The backend is a Python package that handles the heavy lifting (RAG, embeddings, LLM communication).
+Install the isolated command with uv:
 
-1.  Open your terminal.
-2.  Install the package using pip:
-    ```bash
-    pip install obsidianrag
-    ```
-    *Note: We recommend using `pipx` for isolated installation: `pipx install obsidianrag`*
+```bash
+uv tool install obsidianrag==4.0.1
+```
 
-3.  Verify the installation:
-    ```bash
-    obsidianrag --version
-    ```
+Alternatively, use pipx:
 
-## Step 2: Install the Plugin
+```bash
+pipx install obsidianrag==4.0.1
+```
 
-1.  Open Obsidian.
-2.  Go to **Settings** > **Community Plugins**.
-3.  Ensure **Restricted mode** is **OFF**.
-4.  Click **Browse** and search for `Vault RAG`.
-5.  Click **Install**.
-6.  Once installed, click **Enable**.
+Verify the installed command and version:
 
-> **Note**: The plugin is currently pending approval for Community Plugins. For now, you can install manually by downloading from [GitHub Releases](https://github.com/Vasallo94/ObsidianRAG/releases) and placing the files in your `.obsidian/plugins/vault-rag/` folder.
+```bash
+obsidianrag version
+```
 
-## Step 3: Initial Configuration
+## Install the plugin
 
-Upon enabling the plugin, a **Setup Wizard** should appear. If not, you can access settings via **Settings** > **ObsidianRAG**.
+Download these files from the `plugin-v4.0.1` GitHub release:
 
-1.  **Backend Command**: The plugin tries to detect your `obsidianrag` executable.
-    -   If it fails, find the path with `which obsidianrag` (macOS/Linux) or `where obsidianrag` (Windows) and paste it here.
-2.  **Server Port**: Default is `8000`. Change only if this port is occupied.
-3.  **LLM Model**: Select the model you pulled earlier (e.g., `gemma3`).
-    -   *Note: If the dropdown is empty, ensure Ollama is running.*
+- `main.js`
+- `manifest.json`
+- `styles.css`
 
-## Step 4: Verify Installation
+Place them in `<vault>/.obsidian/plugins/vault-rag/`, reload Obsidian, and enable **Vault RAG** under **Settings > Community plugins**.
 
-1.  Check the status bar at the bottom right of Obsidian. It should show **🤖 RAG ●** (Online).
-2.  Click the icon to open the chat view.
-3.  Ask a simple question like "What is in my vault?".
-4.  The first request will trigger an index of your vault. This might take a moment.
+## Configure the plugin
 
-## Troubleshooting
+Open **Settings > Vault RAG** and configure:
 
-If you encounter issues, please refer to the [Troubleshooting Guide](TROUBLESHOOTING.md).
+1. **Backend executable**: `obsidianrag`, `obsidianrag.exe` on Windows, or its absolute path. Do not enter a compound shell command.
+2. **Server port**: `8000` unless another process uses it.
+3. **Model provider**: Ollama, LM Studio, or a compatible custom endpoint.
+4. **Model** and provider URL.
+5. **Auto-start server**, if desired.
+
+Backend and plugin 4.0.1 use API 4 exclusively and reject API 3 counterparts.
+
+## Build the first index
+
+1. Start the backend from the plugin.
+2. Confirm the server is online. It is normal for chat to remain unavailable before indexing.
+3. Select **Build index**.
+4. Wait until index status is current and query-ready.
+5. Open chat and ask a question.
+
+Indexing is always explicit. The first question does not trigger a build.
+
+## Maintain the index
+
+- Select **Refresh index** after adding, editing, or deleting notes. Compatible revisions update incrementally.
+- Select **Full rebuild** when embedding, chunk, or schema settings are incompatible.
+- Select **Prune** to remove inactive revisions after their readers finish.
+
+Legacy `.obsidianrag/db` data from 3.x is ignored and never deleted automatically.
+
+See the [troubleshooting guide](../TROUBLESHOOTING.md) for startup, provider, status, and recovery help.

--- a/docs/user-guide/usage.md
+++ b/docs/user-guide/usage.md
@@ -6,14 +6,14 @@ Requirements:
 
 - Obsidian 1.5 or newer
 - Python 3.11 or newer
-- ObsidianRAG backend 4.0.0
-- Vault RAG plugin 4.0.0
+- ObsidianRAG backend 4.0.1
+- Vault RAG plugin 4.0.1
 - An Ollama, LM Studio, or compatible generation server
 
 Install the backend:
 
 ```bash
-uv tool install obsidianrag==4.0.0
+uv tool install obsidianrag==4.0.1
 ```
 
 Install `main.js`, `manifest.json`, and `styles.css` from the plugin GitHub release into `<vault>/.obsidian/plugins/vault-rag/`, then enable the plugin.
@@ -61,4 +61,4 @@ The command palette includes:
 - Check status
 - Refresh index
 
-API 3 backends are intentionally rejected by plugin 4.0.0.
+API 3 backends are intentionally rejected by plugin 4.0.1.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Desktop Obsidian plugin for ObsidianRAG API 4.
 
 ## Install
 
-1. Install backend 4.0.0: `uv tool install obsidianrag==4.0.0`.
+1. Install backend 4.0.1: `uv tool install obsidianrag==4.0.1`.
 2. Download `main.js`, `manifest.json`, and `styles.css` from the plugin GitHub release.
 3. Place them in `<vault>/.obsidian/plugins/vault-rag/`.
 4. Reload Obsidian and enable **Vault RAG**.

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "vault-rag",
   "name": "Vault RAG",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "minAppVersion": "1.5.0",
   "description": "Ask questions about your notes using local AI and a revisioned hybrid index",
   "author": "Enrique Vasallo",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-rag",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Ask questions about your Obsidian notes using local AI (RAG)",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -644,13 +644,13 @@ export default class ObsidianRAGPlugin extends Plugin {
   // API Methods
   // ==========================================================================
 
-  async askQuestion(question: string): Promise<AskResponse> {
+  async askQuestion(question: string, sessionId?: string): Promise<AskResponse> {
     try {
       const response = await requestUrl({
         url: `${this.apiBaseUrl}/ask`,
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: question }),
+        body: JSON.stringify({ text: question, ...(sessionId ? { session_id: sessionId } : {}) }),
       });
 
       if (response.status < 200 || response.status >= 300) {
@@ -675,18 +675,17 @@ export default class ObsidianRAGPlugin extends Plugin {
    * Note: True streaming is not supported by requestUrl, so we simulate events
    */
   async *askQuestionStreaming(
-    question: string
+    question: string,
+    sessionId?: string
   ): AsyncGenerator<StreamEvent, void, unknown> {
     try {
-      // Emit start event
-      yield { type: "start", session_id: "" };
       yield { type: "status", message: "Sending question..." };
 
       const response = await requestUrl({
         url: `${this.apiBaseUrl}/ask`,
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: question }),
+        body: JSON.stringify({ text: question, ...(sessionId ? { session_id: sessionId } : {}) }),
       });
 
       if (response.status < 200 || response.status >= 300) {
@@ -700,6 +699,8 @@ export default class ObsidianRAGPlugin extends Plugin {
         yield { type: "error", message: data.error };
         return;
       }
+
+      yield { type: "start", session_id: data.session_id };
 
       // Emit retrieve complete event
       yield {
@@ -948,7 +949,7 @@ class SetupModal extends Modal {
     const li2 = requirements.createEl("li");
     li2.createEl("strong", { text: "obsidianrag" });
     li2.appendText(" package - ");
-    li2.createEl("code", { text: "uv tool install obsidianrag==4.0.0" });
+    li2.createEl("code", { text: "uv tool install obsidianrag==4.0.1" });
 
     const li3 = requirements.createEl("li");
 
@@ -1229,9 +1230,10 @@ class AskQuestionModal extends Modal {
 // Chat View
 // ============================================================================
 
-class ChatView extends ItemView {
+export class ChatView extends ItemView {
   plugin: ObsidianRAGPlugin;
   messages: ChatMessage[] = [];
+  private sessionId: string | null = null;
   private containerEl_messages!: HTMLElement;
   private inputEl!: HTMLTextAreaElement;
 
@@ -1338,6 +1340,7 @@ class ChatView extends ItemView {
   }
 
   clearHistory() {
+    this.sessionId = null;
     this.messages = [];
     this.containerEl_messages.empty();
     this.addMessage({
@@ -1367,6 +1370,10 @@ class ChatView extends ItemView {
     const question = this.inputEl.value.trim();
     if (!question) return;
 
+    const sessionId = this.sessionId ?? globalThis.crypto.randomUUID();
+    this.sessionId = sessionId;
+    const sessionIsCurrent = () => this.sessionId === sessionId;
+
     // Add user message
     this.addMessage({
       role: "user",
@@ -1378,6 +1385,7 @@ class ChatView extends ItemView {
 
     // Check if server is running
     if (!(await this.plugin.isServerRunning())) {
+      if (!sessionIsCurrent()) return;
       this.addMessage({
         role: "assistant",
         content:
@@ -1386,7 +1394,9 @@ class ChatView extends ItemView {
       });
       return;
     }
+    if (!sessionIsCurrent()) return;
     const indexStatus = await this.plugin.getIndexStatus();
+    if (!sessionIsCurrent()) return;
     if (!indexStatus?.query_ready) {
       this.addMessage({
         role: "assistant",
@@ -1423,9 +1433,15 @@ class ChatView extends ItemView {
       let finalAnswer: StreamEventAnswer | null = null;
 
       // Use streaming API
-      for await (const event of this.plugin.askQuestionStreaming(question)) {
+      for await (const event of this.plugin.askQuestionStreaming(question, sessionId)) {
+        if (!sessionIsCurrent()) {
+          progressEl.remove();
+          if (streamingEl) streamingEl.remove();
+          return;
+        }
         switch (event.type) {
           case "start":
+            if (this.sessionId === sessionId) this.sessionId = event.session_id;
             updateProgress("Connecting...");
             break;
 
@@ -1503,6 +1519,12 @@ class ChatView extends ItemView {
           case "done":
             break;
         }
+      }
+
+      if (!sessionIsCurrent()) {
+        progressEl.remove();
+        if (streamingEl) streamingEl.remove();
+        return;
       }
 
       // Remove progress if still showing
@@ -1647,6 +1669,7 @@ class ChatView extends ItemView {
       }
     } catch (error) {
       progressEl.remove();
+      if (!sessionIsCurrent()) return;
       this.addMessage({
         role: "assistant",
         content: `Error: ${error}`,
@@ -2025,7 +2048,7 @@ class ObsidianRAGSettingTab extends PluginSettingTab {
     const hLi2 = ul.createEl("li");
     hLi2.createEl("strong", { text: "obsidianrag" });
     hLi2.appendText(" package: ");
-    hLi2.createEl("code", { text: "uv tool install obsidianrag==4.0.0" });
+    hLi2.createEl("code", { text: "uv tool install obsidianrag==4.0.1" });
 
     const hLi3 = ul.createEl("li");
     hLi3.createEl("strong", { text: "Generation provider" });

--- a/plugin/tests/edge-cases.test.ts
+++ b/plugin/tests/edge-cases.test.ts
@@ -1,7 +1,7 @@
 
 import * as child_process from 'child_process';
 import { requestUrl } from 'obsidian';
-import ObsidianRAGPlugin from '../src/main';
+import ObsidianRAGPlugin, { ChatView } from '../src/main';
 
 // Mock child_process
 jest.mock('child_process', () => ({
@@ -228,7 +228,7 @@ describe('Edge Cases', () => {
       (requestUrl as jest.Mock)
         .mockResolvedValueOnce({
           status: 200,
-          json: { api_version: 4, backend_version: '4.0.0' }
+          json: { api_version: 4, backend_version: '4.0.1' }
         })
         .mockResolvedValueOnce({ status: 200, json: { status: 'ok' } });
 
@@ -252,6 +252,85 @@ describe('Edge Cases', () => {
       await plugin.checkServerStatus();
 
       // If no error thrown, it passed the try-catch block
+    });
+  });
+
+  describe('Chat sessions', () => {
+    it('propagates the backend session across two turns', async () => {
+      (requestUrl as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200,
+          json: {
+            result: 'First answer', sources: [], question: 'First', process_time: 0.1,
+            session_id: 'session-1'
+          }
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: {
+            result: 'Second answer', sources: [], question: 'Second', process_time: 0.1,
+            session_id: 'session-1'
+          }
+        });
+
+      const firstEvents = [];
+      for await (const event of plugin.askQuestionStreaming('First')) firstEvents.push(event);
+      const sessionId = firstEvents.find((event: any) => event.type === 'start').session_id;
+      for await (const _event of plugin.askQuestionStreaming('Second', sessionId)) {
+        // consume the simulated stream
+      }
+
+      expect(requestUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        body: JSON.stringify({ text: 'First' })
+      }));
+      expect(requestUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        body: JSON.stringify({ text: 'Second', session_id: 'session-1' })
+      }));
+    });
+
+    it('clearing a chat resets its session ID', () => {
+      const view = new ChatView({} as any, plugin);
+      (view as any).sessionId = 'session-1';
+      (view as any).containerEl_messages = { empty: jest.fn() };
+      view.addMessage = jest.fn();
+
+      view.clearHistory();
+
+      expect((view as any).sessionId).toBeNull();
+    });
+
+    it('clear invalidates a turn waiting for readiness checks', async () => {
+      let resolveRunning!: (running: boolean) => void;
+      plugin.isServerRunning = jest.fn(() => new Promise<boolean>((resolve) => {
+        resolveRunning = resolve;
+      }));
+      plugin.getIndexStatus = jest.fn().mockResolvedValue({ query_ready: true });
+      plugin.askQuestionStreaming = jest.fn(async function* () { return; });
+
+      const progressContent = {
+        empty: jest.fn(), createEl: jest.fn(), createSpan: jest.fn()
+      };
+      const progressEl = {
+        createDiv: jest.fn().mockReturnValue(progressContent),
+        remove: jest.fn(), parentElement: null
+      };
+      const view = new ChatView({} as any, plugin);
+      (view as any).inputEl = { value: 'First question' };
+      (view as any).containerEl_messages = {
+        empty: jest.fn(), createDiv: jest.fn().mockReturnValue(progressEl),
+        scrollTop: 0, scrollHeight: 0
+      };
+      view.addMessage = jest.fn();
+
+      const pending = view.sendMessage();
+      await Promise.resolve();
+      view.clearHistory();
+      resolveRunning(true);
+      await pending;
+
+      expect((view as any).sessionId).toBeNull();
+      expect(plugin.getIndexStatus).not.toHaveBeenCalled();
+      expect(plugin.askQuestionStreaming).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses the independent retrospective review of 4.0.0:

- reject Windows reparse points and junctions on Python 3.11
- exercise Windows Python 3.11 explicitly in CI with real junction coverage
- preserve one backend session per plugin chat view and invalidate in-flight turns on Clear
- serialize same-session backend requests without blocking independent sessions
- include the MIT license in backend wheel and sdist, with release verification
- correct the v4 installation guide
- bump backend and plugin together to 4.0.1

## Validation

Backend:

- `uv run pytest -q -m 'not integration and not slow'` — 132 passed, 2 platform skips
- focused server/index tests — 48 passed, 2 platform skips
- Ruff, format, and mypy passed
- `uv build` produced 4.0.1 wheel and sdist
- `scripts/verify_dist.py` verified LICENSE in both artifacts

Plugin:

- Jest — 45 passed
- ESLint passed
- TypeScript and production build passed

## Safety

- No personal vault was indexed.
- No Ollama or real model request was started.
- Real junction behavior remains gated on Windows CI before merge.
